### PR TITLE
Add explicit collector registry support

### DIFF
--- a/src/Prometheus/PrometheusDiagnosticContextFactory.cs
+++ b/src/Prometheus/PrometheusDiagnosticContextFactory.cs
@@ -14,9 +14,9 @@ namespace Mindbox.DiagnosticContext.Prometheus
 			this.metricFactory = metricFactory ?? Metrics.WithCustomRegistry(Metrics.DefaultRegistry);
 		}
 
-		public PrometheusDiagnosticContextFactory(CollectorRegistry metricRegistry)
+		public PrometheusDiagnosticContextFactory(CollectorRegistry collectorRegistry)
 		{
-			this.metricFactory = Metrics.WithCustomRegistry(metricRegistry);
+			this.metricFactory = Metrics.WithCustomRegistry(collectorRegistry);
 		}
 
 		public IDiagnosticContext CreateDiagnosticContext(


### PR DESCRIPTION
mindbox-moscow/issues-devcore#1467

В этом ПРе добавил поддержку фабрики для диагностик контекста с явно заданным `CollectorRegistry` из библиотеки прометеуса.

И можешь, пожалуйста провалидировать дальнейший план:

- В `Mindbox.Framework` у местного абстрактного `MetricRegistry` хочу опубличить [InnerRegistry](https://github.com/mindbox-moscow/Mindbox.Framework/blob/c1ee80d99283beee6eb11f1ff5e399e49ab74039/Commons/Commons.Model/Metrics/MetricsRegistry.cs#L43) - это `CollectorRegistry`, который используется им (и всеми наследниками) под капотом.

- После этого в `DirectCRM` можно будет зарегистрировать фабрику диагностик контекста как-то так:

```
	services.AddSingleton<IDiagnosticContextFactory>(
		serviceProvider =>
		{
			var applicationConfiguration = ModelApplicationHostController.Instance.ApplicationConfiguration;
			var diagnosticContextService = applicationConfiguration
				.Get<PushGatewayServiceDiscoveryConfigurationSection>()
				.GetCommonDiagnosticContextPushGatewayService();

			var metricsRegistry = serviceProvider.GetService<IMetricsRegistryFactory>().CreateAutoPushedMetricRegistry(
				job: "common-dc",
				instance: $"{Environment.MachineName}-{applicationConfiguration.ProjectSystemName}",
				endpoint: diagnosticContextService.Endpoint,
				intervalMilliseconds: diagnosticContextService.Interval,
				useDefaultRegistry: false);

			return new PrometheusDiagnosticContextFactory(metricsRegistry.InnerRegistry);
```

- И как я понимаю, позже, в другом ишью с помощью этой фабрики в `ItcController` нужно будет заменить дефолтную диагностику с `NewRelic`. Затем чуваки точечно переведут все свои кастомные плагины.