### PR TITLE
Safely get diagnostic context from http one (HttpContext.Items throw …

### DIFF
--- a/src/AspNetCore/DiagnosticContextAccessorExtensions.cs
+++ b/src/AspNetCore/DiagnosticContextAccessorExtensions.cs
@@ -22,7 +22,12 @@ namespace Mindbox.DiagnosticContext.AspNetCore
 
 		public static IDiagnosticContext GetDiagnosticContext(this HttpContext httpContext)
 		{
-			return httpContext.Items[DiagnosticContextItemKey] as IDiagnosticContext ?? new NullDiagnosticContext();
+			if (httpContext.Items.TryGetValue(DiagnosticContextItemKey, out var item))
+			{
+				if (item is IDiagnosticContext context) return context;
+			}
+
+			return new NullDiagnosticContext();
 		}
 
 		internal static void StoreDiagnosticContext(this HttpContext httpContext, IDiagnosticContext diagnosticContext)


### PR DESCRIPTION
…exception when the key is not contained in the collection)