### PR TITLE
Add managed lifetime support for DiagnosticContext metrics

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,7 +14,7 @@
     <PackageTags>diagnostics</PackageTags>
   </PropertyGroup>
   <PropertyGroup>
-    <VersionMajor>10</VersionMajor>
+    <VersionMajor>11</VersionMajor>
     <VersionMinor>0</VersionMinor>
     <BuildNumber>$(BuildNumber)</BuildNumber>
     <BuildNumber Condition="'$(BuildNumber)' == ''">0</BuildNumber>

--- a/src/Prometheus.Tests/DiagnosticContextTests.cs
+++ b/src/Prometheus.Tests/DiagnosticContextTests.cs
@@ -521,7 +521,7 @@ public class ManagedLifetimeDiagnosticContextTests : DiagnosticContextTestsBase
 		Assert.IsTrue(before.Contains("tag=\"ephemeral\""),
 			$"Should be present immediately.\n{before}");
 
-		await System.Threading.Tasks.Task.Delay(TimeSpan.FromMilliseconds(2000));
+		await System.Threading.Tasks.Task.Delay(TimeSpan.FromMilliseconds(500));
 
 		var after = await Collect();
 		Assert.IsFalse(after.Contains("tag=\"ephemeral\""),

--- a/src/Prometheus.Tests/DiagnosticContextTests.cs
+++ b/src/Prometheus.Tests/DiagnosticContextTests.cs
@@ -487,44 +487,4 @@ public class ManagedLifetimeDiagnosticContextTests : DiagnosticContextTestsBase
 		IDiagnosticContextLogger logger,
 		IMetricFactory metricFactory)
 		=> new(config, logger, TimeSpan.FromMinutes(5), metricFactory);
-
-	[TestMethod]
-	public async System.Threading.Tasks.Task SeriesEvictedAfterTtlAsync()
-	{
-		var registry = Metrics.NewCustomRegistry();
-		var factory = new PrometheusDiagnosticContextFactory(
-			_defaultMetricTypesConfiguration,
-			new NullDiagnosticContextLogger(),
-			metricLifetime: TimeSpan.FromMilliseconds(100),
-			metricFactory: Metrics.WithCustomRegistry(registry));
-
-		var metricsTypes = _defaultMetricTypesConfiguration
-			.GetDefaultMetricsTypes()
-			.MetricsTypes
-			.ToArray();
-
-		using (var dc = factory.CreateDiagnosticContext("Evict", metricsTypesOverride: metricsTypes))
-		{
-			dc.SetTag("tag", "ephemeral");
-			using (dc.Measure("Span"))
-				_currentTimeAccessor.CurrentDateTimeUtc = _currentTimeAccessor.CurrentDateTimeUtc.AddMilliseconds(1);
-		}
-
-		async System.Threading.Tasks.Task<string> Collect()
-		{
-			using var ms = new MemoryStream();
-			await registry.CollectAndExportAsTextAsync(ms);
-			return Encoding.UTF8.GetString(ms.ToArray());
-		}
-
-		var before = await Collect();
-		Assert.IsTrue(before.Contains("tag=\"ephemeral\""),
-			$"Should be present immediately.\n{before}");
-
-		await System.Threading.Tasks.Task.Delay(TimeSpan.FromMilliseconds(500));
-
-		var after = await Collect();
-		Assert.IsFalse(after.Contains("tag=\"ephemeral\""),
-			$"Should be evicted after TTL.\n{after}");
-	}
 }

--- a/src/Prometheus.Tests/DiagnosticContextTests.cs
+++ b/src/Prometheus.Tests/DiagnosticContextTests.cs
@@ -521,7 +521,7 @@ public class ManagedLifetimeDiagnosticContextTests : DiagnosticContextTestsBase
 		Assert.IsTrue(before.Contains("tag=\"ephemeral\""),
 			$"Should be present immediately.\n{before}");
 
-		await System.Threading.Tasks.Task.Delay(TimeSpan.FromMilliseconds(500));
+		await System.Threading.Tasks.Task.Delay(TimeSpan.FromMilliseconds(2000));
 
 		var after = await Collect();
 		Assert.IsFalse(after.Contains("tag=\"ephemeral\""),

--- a/src/Prometheus.Tests/DiagnosticContextTests.cs
+++ b/src/Prometheus.Tests/DiagnosticContextTests.cs
@@ -28,14 +28,17 @@ public class TestDateTimeAccessor : ICurrentTimeAccessor
 	public DateTime CurrentDateTimeUtc { get; set; }
 }
 
-[TestClass]
-public class DiagnosticContextTests
+public abstract class DiagnosticContextTestsBase
 {
-	private CollectorRegistry _metricsRegistry = null!;
-	private PrometheusDiagnosticContextFactory _factory = null!;
-	private TestDateTimeAccessor _currentTimeAccessor = null!;
-	private DefaultMetricTypesConfiguration _defaultMetricTypesConfiguration = null!;
+	protected CollectorRegistry _metricsRegistry = null!;
+	protected PrometheusDiagnosticContextFactory _factory = null!;
+	protected TestDateTimeAccessor _currentTimeAccessor = null!;
+	protected DefaultMetricTypesConfiguration _defaultMetricTypesConfiguration = null!;
 
+	protected abstract PrometheusDiagnosticContextFactory CreateFactory(
+		DefaultMetricTypesConfiguration config,
+		IDiagnosticContextLogger logger,
+		IMetricFactory metricFactory);
 
 	[TestInitialize]
 	public void TestInitialize()
@@ -46,7 +49,7 @@ public class DiagnosticContextTests
 			CurrentDateTimeUtc = new DateTime(2021, 02, 03, 04, 05, 06, 07, DateTimeKind.Utc)
 		};
 		_defaultMetricTypesConfiguration = new DefaultMetricTypesConfiguration(_currentTimeAccessor);
-		_factory = new PrometheusDiagnosticContextFactory(
+		_factory = CreateFactory(
 			_defaultMetricTypesConfiguration,
 			new NullDiagnosticContextLogger(),
 			Metrics.WithCustomRegistry(_metricsRegistry));
@@ -116,7 +119,6 @@ public class DiagnosticContextTests
 			}
 		}
 
-
 		Measure(1);
 		Measure(2);
 		await AssertMetricsReportedAsync(
@@ -138,7 +140,6 @@ public class DiagnosticContextTests
 				_currentTimeAccessor.CurrentDateTimeUtc = _currentTimeAccessor.CurrentDateTimeUtc.AddMilliseconds(milliseconds);
 			}
 		}
-
 
 		Measure("tagValue1", 1);
 		Measure("tagValue2", 2);
@@ -377,22 +378,6 @@ public class DiagnosticContextTests
 			"diagnosticcontext_test_reportedvalues_count{name=\"TestValue\",tag=\"tagValue2\"} 1");
 	}
 
-	private async System.Threading.Tasks.Task AssertMetricsReportedAsync(params string[] expectedMetrics)
-	{
-		var metrics = await GetMetricsAsTextAsync();
-
-		var notFoundMetrics = expectedMetrics
-			.Where(metric => !metrics.Contains(metric))
-			.ToArray();
-
-		if (notFoundMetrics.Any())
-		{
-			Assert.Fail(
-				$"Following metrics where not reported:\r\n{string.Join("\r\n", notFoundMetrics)}\r\n\r\n" +
-				$"Full metrics:\r\n{metrics}");
-		}
-	}
-
 	[TestMethod]
 	public async System.Threading.Tasks.Task InternalMetrics_ProcessingTime()
 	{
@@ -435,7 +420,23 @@ public class DiagnosticContextTests
 		await AssertMetricsReportedAsync("diagnosticcontext_test_processingtime_layerscount{tag=\"tagValue\"} 3");
 	}
 
-	private async System.Threading.Tasks.Task AssertMetricsNotReportedAsync(params string[] expectedMetrics)
+	protected async System.Threading.Tasks.Task AssertMetricsReportedAsync(params string[] expectedMetrics)
+	{
+		var metrics = await GetMetricsAsTextAsync();
+
+		var notFoundMetrics = expectedMetrics
+			.Where(metric => !metrics.Contains(metric))
+			.ToArray();
+
+		if (notFoundMetrics.Any())
+		{
+			Assert.Fail(
+				$"Following metrics where not reported:\r\n{string.Join("\r\n", notFoundMetrics)}\r\n\r\n" +
+				$"Full metrics:\r\n{metrics}");
+		}
+	}
+
+	protected async System.Threading.Tasks.Task AssertMetricsNotReportedAsync(params string[] expectedMetrics)
 	{
 		var metrics = await GetMetricsAsTextAsync();
 
@@ -451,7 +452,7 @@ public class DiagnosticContextTests
 		}
 	}
 
-	private IDiagnosticContext CreateDiagnosticContext(string metricPath)
+	protected IDiagnosticContext CreateDiagnosticContext(string metricPath)
 	{
 		var onlyWallClockMetricTypes = _defaultMetricTypesConfiguration
 			.GetDefaultMetricsTypes()
@@ -460,10 +461,70 @@ public class DiagnosticContextTests
 		return _factory.CreateDiagnosticContext(metricPath, metricsTypesOverride: onlyWallClockMetricTypes);
 	}
 
-	private async System.Threading.Tasks.Task<string> GetMetricsAsTextAsync()
+	protected async System.Threading.Tasks.Task<string> GetMetricsAsTextAsync()
 	{
 		using var memoryStream = new MemoryStream();
 		await _metricsRegistry.CollectAndExportAsTextAsync(memoryStream);
 		return Encoding.UTF8.GetString(memoryStream.ToArray());
+	}
+}
+
+[TestClass]
+public class PlainDiagnosticContextTests : DiagnosticContextTestsBase
+{
+	protected override PrometheusDiagnosticContextFactory CreateFactory(
+		DefaultMetricTypesConfiguration config,
+		IDiagnosticContextLogger logger,
+		IMetricFactory metricFactory)
+		=> new(config, logger, metricFactory);
+}
+
+[TestClass]
+public class ManagedLifetimeDiagnosticContextTests : DiagnosticContextTestsBase
+{
+	protected override PrometheusDiagnosticContextFactory CreateFactory(
+		DefaultMetricTypesConfiguration config,
+		IDiagnosticContextLogger logger,
+		IMetricFactory metricFactory)
+		=> new(config, logger, TimeSpan.FromMinutes(5), metricFactory);
+
+	[TestMethod]
+	public async System.Threading.Tasks.Task SeriesEvictedAfterTtlAsync()
+	{
+		var registry = Metrics.NewCustomRegistry();
+		var factory = new PrometheusDiagnosticContextFactory(
+			_defaultMetricTypesConfiguration,
+			new NullDiagnosticContextLogger(),
+			metricLifetime: TimeSpan.FromMilliseconds(100),
+			metricFactory: Metrics.WithCustomRegistry(registry));
+
+		var metricsTypes = _defaultMetricTypesConfiguration
+			.GetDefaultMetricsTypes()
+			.MetricsTypes
+			.ToArray();
+
+		using (var dc = factory.CreateDiagnosticContext("Evict", metricsTypesOverride: metricsTypes))
+		{
+			dc.SetTag("tag", "ephemeral");
+			using (dc.Measure("Span"))
+				_currentTimeAccessor.CurrentDateTimeUtc = _currentTimeAccessor.CurrentDateTimeUtc.AddMilliseconds(1);
+		}
+
+		async System.Threading.Tasks.Task<string> Collect()
+		{
+			using var ms = new MemoryStream();
+			await registry.CollectAndExportAsTextAsync(ms);
+			return Encoding.UTF8.GetString(ms.ToArray());
+		}
+
+		var before = await Collect();
+		Assert.IsTrue(before.Contains("tag=\"ephemeral\""),
+			$"Should be present immediately.\n{before}");
+
+		await System.Threading.Tasks.Task.Delay(TimeSpan.FromMilliseconds(500));
+
+		var after = await Collect();
+		Assert.IsFalse(after.Contains("tag=\"ephemeral\""),
+			$"Should be evicted after TTL.\n{after}");
 	}
 }

--- a/src/Prometheus/CountersPrometheusAdapter.cs
+++ b/src/Prometheus/CountersPrometheusAdapter.cs
@@ -23,7 +23,7 @@ internal class CountersPrometheusAdapter
 
 	private readonly PrometheusMetricNameBuilder _metricNameBuilder;
 
-	private readonly Dictionary<string, ILabeledMetric> _prometheusCounters = new();
+	private readonly Dictionary<string, ICounterAdapter> _prometheusCounters = new();
 
 	public CountersPrometheusAdapter(DiagnosticMetricCreator metricCreator, PrometheusMetricNameBuilder metricNameBuilder)
 	{
@@ -50,7 +50,7 @@ internal class CountersPrometheusAdapter
 		}
 	}
 
-	private ILabeledMetric GetOrCreatePrometheusCounter(
+	private ICounterAdapter GetOrCreatePrometheusCounter(
 		DiagnosticContextMetricsItem metricsItem,
 		string counterName,
 		IDictionary<string, string> tags)

--- a/src/Prometheus/CountersPrometheusAdapter.cs
+++ b/src/Prometheus/CountersPrometheusAdapter.cs
@@ -1,11 +1,11 @@
 // Copyright 2021 Mindbox Ltd
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,21 +14,20 @@
 
 using System.Collections.Generic;
 using Mindbox.DiagnosticContext.MetricItem;
-using Prometheus;
 
 namespace Mindbox.DiagnosticContext.Prometheus;
 
 internal class CountersPrometheusAdapter
 {
-	private readonly IMetricFactory _metricFactory;
+	private readonly DiagnosticMetricCreator _metricCreator;
 
 	private readonly PrometheusMetricNameBuilder _metricNameBuilder;
 
-	private readonly Dictionary<string, Counter> _prometheusCounters = new();
+	private readonly Dictionary<string, ILabeledMetric> _prometheusCounters = new();
 
-	public CountersPrometheusAdapter(IMetricFactory metricFactory, PrometheusMetricNameBuilder metricNameBuilder)
+	public CountersPrometheusAdapter(DiagnosticMetricCreator metricCreator, PrometheusMetricNameBuilder metricNameBuilder)
 	{
-		_metricFactory = metricFactory;
+		_metricCreator = metricCreator;
 		_metricNameBuilder = metricNameBuilder;
 	}
 
@@ -46,14 +45,12 @@ internal class CountersPrometheusAdapter
 				var labelValues = new List<string> { diagnosticContextCounter.Key };
 				labelValues.AddRange(tags.Values);
 
-				prometheusCounter
-					.WithLabels(labelValues.ToArray())
-					.Inc(diagnosticContextCounter.Value);
+				prometheusCounter.Inc(labelValues.ToArray(), diagnosticContextCounter.Value);
 			}
 		}
 	}
 
-	private Counter GetOrCreatePrometheusCounter(
+	private ILabeledMetric GetOrCreatePrometheusCounter(
 		DiagnosticContextMetricsItem metricsItem,
 		string counterName,
 		IDictionary<string, string> tags)
@@ -66,10 +63,10 @@ internal class CountersPrometheusAdapter
 			var labelNames = new List<string> { "name" };
 			labelNames.AddRange(tags.Keys);
 
-			prometheusCounter = _metricFactory.CreateCounter(
+			prometheusCounter = _metricCreator.CreateCounter(
 				metricName,
 				metricDescription,
-				new CounterConfiguration() { LabelNames = labelNames.ToArray() });
+				labelNames.ToArray());
 
 			_prometheusCounters[counterName] = prometheusCounter;
 		}

--- a/src/Prometheus/DiagnosticContextInternalMetricsAdapter.cs
+++ b/src/Prometheus/DiagnosticContextInternalMetricsAdapter.cs
@@ -15,19 +15,20 @@
 using System.Collections.Generic;
 using System.Linq;
 using Mindbox.DiagnosticContext.MetricItem;
-using Prometheus;
 
 namespace Mindbox.DiagnosticContext.Prometheus;
 
 internal class DiagnosticContextInternalMetricsAdapter
 {
-	private readonly IMetricFactory _metricFactory;
+	private readonly DiagnosticMetricCreator _metricCreator;
 
 	private readonly PrometheusMetricNameBuilder _metricNameBuilder;
 
-	public DiagnosticContextInternalMetricsAdapter(IMetricFactory metricFactory, PrometheusMetricNameBuilder metricNameBuilder)
+	public DiagnosticContextInternalMetricsAdapter(
+		DiagnosticMetricCreator metricCreator,
+		PrometheusMetricNameBuilder metricNameBuilder)
 	{
-		_metricFactory = metricFactory;
+		_metricCreator = metricCreator;
 		_metricNameBuilder = metricNameBuilder;
 	}
 
@@ -40,35 +41,32 @@ internal class DiagnosticContextInternalMetricsAdapter
 		var labelValues = tags.Values.ToArray();
 
 		var metricDescriptionBase = $"Diagnostic context {collectedMetrics.MetricPrefix} ";
-		
-		var countCounter = _metricFactory.CreateCounter(
+
+		var countCounter = _metricCreator.CreateCounter(
 			_metricNameBuilder.BuildFullMetricName(
 			$"{collectedMetrics.MetricPrefix}_internalmetrics_count"),
 			$"{metricDescriptionBase} - internal metrics count",
-			new CounterConfiguration { LabelNames = labelNames });
+			labelNames);
 
-		countCounter.WithLabels(labelValues).Inc();
+		countCounter.Inc(labelValues, 1);
 
-		var internalProcessingCounter = _metricFactory.CreateCounter(
+		var internalProcessingCounter = _metricCreator.CreateCounter(
 			_metricNameBuilder.BuildFullMetricName(
 			$"{collectedMetrics.MetricPrefix}_{internalMetricsItem.ProcessingTimeMeasurer.MetricTypeSystemName}"),
 			$"{metricDescriptionBase} - internal processing time",
-			new CounterConfiguration { LabelNames = labelNames });
+			labelNames);
 
-		internalProcessingCounter
-			.WithLabels(labelValues)
-			.Inc(internalMetricsItem.ProcessingTimeMeasurer.Elapsed);
+		internalProcessingCounter.Inc(labelValues, internalMetricsItem.ProcessingTimeMeasurer.Elapsed);
 
 		foreach (var measurer in internalMetricsItem.LayersCountMeasurers)
 		{
-			var layersCounter = _metricFactory.CreateCounter(
-				_metricNameBuilder.BuildFullMetricName($"{collectedMetrics.MetricPrefix}_{measurer.MetricTypeSystemName}"),
+			var layersCounter = _metricCreator.CreateCounter(
+				_metricNameBuilder.BuildFullMetricName(
+					$"{collectedMetrics.MetricPrefix}_{measurer.MetricTypeSystemName}"),
 				$"{metricDescriptionBase} - layers count",
-				new CounterConfiguration { LabelNames = labelNames});
+				labelNames);
 
-			layersCounter
-				.WithLabels(labelValues)
-				.Inc(measurer.LayersCount);
+			layersCounter.Inc(labelValues, measurer.LayersCount);
 		}
 	}
 }

--- a/src/Prometheus/DiagnosticMetricCreator.cs
+++ b/src/Prometheus/DiagnosticMetricCreator.cs
@@ -36,14 +36,14 @@ internal sealed class DiagnosticMetricCreator
 		if (_managedFactory != null)
 		{
 			var handle = _managedFactory.CreateCounter(name, help, labelNames);
-			return new ManagedLabeledMetric(handle.WithExtendLifetimeOnUse());
+			return new ManagedCounterAdapter(handle.WithExtendLifetimeOnUse());
 		}
 
 		var counter = _plainFactory!.CreateCounter(
 			name,
 			help,
 			new CounterConfiguration { LabelNames = labelNames });
-		return new PlainLabeledMetric(counter);
+		return new PlainCounterAdapter(counter);
 	}
 }
 
@@ -52,21 +52,21 @@ internal interface ICounterAdapter
 	void Inc(string[] labelValues, double amount);
 }
 
-internal sealed class PlainLabeledMetric : ICounterAdapter
+internal sealed class PlainCounterAdapter : ICounterAdapter
 {
 	private readonly Counter _counter;
 
-	public PlainLabeledMetric(Counter counter) => _counter = counter;
+	public PlainCounterAdapter(Counter counter) => _counter = counter;
 
 	public void Inc(string[] labelValues, double amount) =>
 		_counter.WithLabels(labelValues).Inc(amount);
 }
 
-internal sealed class ManagedLabeledMetric : ICounterAdapter
+internal sealed class ManagedCounterAdapter : ICounterAdapter
 {
 	private readonly ICollector<ICounter> _collector;
 
-	public ManagedLabeledMetric(ICollector<ICounter> collector) => _collector = collector;
+	public ManagedCounterAdapter(ICollector<ICounter> collector) => _collector = collector;
 
 	public void Inc(string[] labelValues, double amount) =>
 		_collector.WithLabels(labelValues).Inc(amount);

--- a/src/Prometheus/DiagnosticMetricCreator.cs
+++ b/src/Prometheus/DiagnosticMetricCreator.cs
@@ -19,7 +19,7 @@ namespace Mindbox.DiagnosticContext.Prometheus;
 internal sealed class DiagnosticMetricCreator
 {
 	private readonly IMetricFactory? _plainFactory;
-	private readonly IManagedLifetimeMetricFactory? _managedFactory;
+	private readonly IManagedLifetimeMetricFactory? _managedLifetimeFactory;
 
 	public DiagnosticMetricCreator(IMetricFactory factory)
 	{
@@ -28,15 +28,15 @@ internal sealed class DiagnosticMetricCreator
 
 	public DiagnosticMetricCreator(IManagedLifetimeMetricFactory factory)
 	{
-		_managedFactory = factory;
+		_managedLifetimeFactory = factory;
 	}
 
 	public ICounterAdapter CreateCounter(string name, string help, string[] labelNames)
 	{
-		if (_managedFactory != null)
+		if (_managedLifetimeFactory != null)
 		{
-			var handle = _managedFactory.CreateCounter(name, help, labelNames);
-			return new ManagedCounterAdapter(handle.WithExtendLifetimeOnUse());
+			var handle = _managedLifetimeFactory.CreateCounter(name, help, labelNames);
+			return new ManagedLifetimeCounterAdapter(handle.WithExtendLifetimeOnUse());
 		}
 
 		var counter = _plainFactory!.CreateCounter(
@@ -62,11 +62,11 @@ internal sealed class PlainCounterAdapter : ICounterAdapter
 		_counter.WithLabels(labelValues).Inc(amount);
 }
 
-internal sealed class ManagedCounterAdapter : ICounterAdapter
+internal sealed class ManagedLifetimeCounterAdapter : ICounterAdapter
 {
 	private readonly ICollector<ICounter> _collector;
 
-	public ManagedCounterAdapter(ICollector<ICounter> collector) => _collector = collector;
+	public ManagedLifetimeCounterAdapter(ICollector<ICounter> collector) => _collector = collector;
 
 	public void Inc(string[] labelValues, double amount) =>
 		_collector.WithLabels(labelValues).Inc(amount);

--- a/src/Prometheus/DiagnosticMetricCreator.cs
+++ b/src/Prometheus/DiagnosticMetricCreator.cs
@@ -31,7 +31,7 @@ internal sealed class DiagnosticMetricCreator
 		_managedFactory = factory;
 	}
 
-	public ILabeledMetric CreateCounter(string name, string help, string[] labelNames)
+	public ICounterAdapter CreateCounter(string name, string help, string[] labelNames)
 	{
 		if (_managedFactory != null)
 		{
@@ -47,12 +47,12 @@ internal sealed class DiagnosticMetricCreator
 	}
 }
 
-internal interface ILabeledMetric
+internal interface ICounterAdapter
 {
 	void Inc(string[] labelValues, double amount);
 }
 
-internal sealed class PlainLabeledMetric : ILabeledMetric
+internal sealed class PlainLabeledMetric : ICounterAdapter
 {
 	private readonly Counter _counter;
 
@@ -62,7 +62,7 @@ internal sealed class PlainLabeledMetric : ILabeledMetric
 		_counter.WithLabels(labelValues).Inc(amount);
 }
 
-internal sealed class ManagedLabeledMetric : ILabeledMetric
+internal sealed class ManagedLabeledMetric : ICounterAdapter
 {
 	private readonly ICollector<ICounter> _collector;
 

--- a/src/Prometheus/DiagnosticMetricCreator.cs
+++ b/src/Prometheus/DiagnosticMetricCreator.cs
@@ -1,0 +1,73 @@
+// Copyright 2021 Mindbox Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Prometheus;
+
+namespace Mindbox.DiagnosticContext.Prometheus;
+
+internal sealed class DiagnosticMetricCreator
+{
+	private readonly IMetricFactory? _plainFactory;
+	private readonly IManagedLifetimeMetricFactory? _managedFactory;
+
+	public DiagnosticMetricCreator(IMetricFactory factory)
+	{
+		_plainFactory = factory;
+	}
+
+	public DiagnosticMetricCreator(IManagedLifetimeMetricFactory factory)
+	{
+		_managedFactory = factory;
+	}
+
+	public ILabeledMetric CreateCounter(string name, string help, string[] labelNames)
+	{
+		if (_managedFactory != null)
+		{
+			var handle = _managedFactory.CreateCounter(name, help, labelNames);
+			return new ManagedLabeledMetric(handle.WithExtendLifetimeOnUse());
+		}
+
+		var counter = _plainFactory!.CreateCounter(
+			name,
+			help,
+			new CounterConfiguration { LabelNames = labelNames });
+		return new PlainLabeledMetric(counter);
+	}
+}
+
+internal interface ILabeledMetric
+{
+	void Inc(string[] labelValues, double amount);
+}
+
+internal sealed class PlainLabeledMetric : ILabeledMetric
+{
+	private readonly Counter _counter;
+
+	public PlainLabeledMetric(Counter counter) => _counter = counter;
+
+	public void Inc(string[] labelValues, double amount) =>
+		_counter.WithLabels(labelValues).Inc(amount);
+}
+
+internal sealed class ManagedLabeledMetric : ILabeledMetric
+{
+	private readonly ICollector<ICounter> _collector;
+
+	public ManagedLabeledMetric(ICollector<ICounter> collector) => _collector = collector;
+
+	public void Inc(string[] labelValues, double amount) =>
+		_collector.WithLabels(labelValues).Inc(amount);
+}

--- a/src/Prometheus/DiagnosticMetricCreator.cs
+++ b/src/Prometheus/DiagnosticMetricCreator.cs
@@ -12,39 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Prometheus;
 
 namespace Mindbox.DiagnosticContext.Prometheus;
 
 internal sealed class DiagnosticMetricCreator
 {
-	private readonly IMetricFactory? _plainFactory;
-	private readonly IManagedLifetimeMetricFactory? _managedLifetimeFactory;
+	private readonly Func<string, string, string[], ICounterAdapter> _createCounter;
 
 	public DiagnosticMetricCreator(IMetricFactory factory)
 	{
-		_plainFactory = factory;
+		_createCounter = (name, help, labelNames) =>
+			new PlainCounterAdapter(factory.CreateCounter(name, help,
+				new CounterConfiguration { LabelNames = labelNames }));
 	}
 
 	public DiagnosticMetricCreator(IManagedLifetimeMetricFactory factory)
 	{
-		_managedLifetimeFactory = factory;
+		_createCounter = (name, help, labelNames) =>
+			new ManagedLifetimeCounterAdapter(
+				factory.CreateCounter(name, help, labelNames).WithExtendLifetimeOnUse());
 	}
 
-	public ICounterAdapter CreateCounter(string name, string help, string[] labelNames)
-	{
-		if (_managedLifetimeFactory != null)
-		{
-			var handle = _managedLifetimeFactory.CreateCounter(name, help, labelNames);
-			return new ManagedLifetimeCounterAdapter(handle.WithExtendLifetimeOnUse());
-		}
-
-		var counter = _plainFactory!.CreateCounter(
-			name,
-			help,
-			new CounterConfiguration { LabelNames = labelNames });
-		return new PlainCounterAdapter(counter);
-	}
+	public ICounterAdapter CreateCounter(string name, string help, string[] labelNames) =>
+		_createCounter(name, help, labelNames);
 }
 
 internal interface ICounterAdapter

--- a/src/Prometheus/DynamicStepsPrometheusAdapter.cs
+++ b/src/Prometheus/DynamicStepsPrometheusAdapter.cs
@@ -1,11 +1,11 @@
 // Copyright 2021 Mindbox Ltd
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,22 +16,21 @@ using System.Collections.Generic;
 using System.Linq;
 using Mindbox.DiagnosticContext.DynamicStepsAggregatedStorage;
 using Mindbox.DiagnosticContext.MetricItem;
-using Prometheus;
 
 namespace Mindbox.DiagnosticContext.Prometheus;
 
 internal class DynamicStepsPrometheusAdapter
 {
-	private readonly IMetricFactory _metricFactory;
+	private readonly DiagnosticMetricCreator _metricCreator;
 
 	private readonly PrometheusMetricNameBuilder _metricNameBuilder;
 
 	private readonly Dictionary<(string, MetricsType), StepPrometheusCounterSet> _dynamicStepsPrometheusCounters =
 		new();
 
-	public DynamicStepsPrometheusAdapter(IMetricFactory metricFactory, PrometheusMetricNameBuilder metricNameBuilder)
+	public DynamicStepsPrometheusAdapter(DiagnosticMetricCreator metricCreator, PrometheusMetricNameBuilder metricNameBuilder)
 	{
-		_metricFactory = metricFactory;
+		_metricCreator = metricCreator;
 		_metricNameBuilder = metricNameBuilder;
 	}
 
@@ -49,11 +48,9 @@ internal class DynamicStepsPrometheusAdapter
 				var totalLabelValues = tags.Values.ToArray();
 
 				prometheusCounterSet.CountCounter
-					.WithLabels(totalLabelValues)
-					.Inc(metricValue.TotalValue.Count);
+					.Inc(totalLabelValues, metricValue.TotalValue.Count);
 				prometheusCounterSet.TotalCounter
-					.WithLabels(totalLabelValues)
-					.Inc(metricValue.TotalValue.Total);
+					.Inc(totalLabelValues, metricValue.TotalValue.Total);
 
 				foreach (var step in metricValue.StepValues.Where(s => s.Value.Total > 0))
 				{
@@ -62,10 +59,8 @@ internal class DynamicStepsPrometheusAdapter
 						.Append(metricValue.MetricsType.Units)
 						.ToArray();
 
-					prometheusCounterSet
-						.StepCounter
-						.WithLabels(stepLabelValues)
-						.Inc(step.Value.Total);
+					prometheusCounterSet.StepCounter
+						.Inc(stepLabelValues, step.Value.Total);
 				}
 			}
 		}
@@ -89,22 +84,20 @@ internal class DynamicStepsPrometheusAdapter
 				.Append("step")
 				.Append("unit")
 				.ToArray();
-			var counterConfiguration = new CounterConfiguration { LabelNames = totalLabelNames.ToArray() };
 
 			counterSet = new StepPrometheusCounterSet(
-				_metricFactory.CreateCounter(
+				_metricCreator.CreateCounter(
 					_metricNameBuilder.BuildFullMetricName($"{metricNameBase}_Count"),
 					$"{metricDescriptionBase} - total count",
-					counterConfiguration),
-				_metricFactory.CreateCounter(
+					totalLabelNames),
+				_metricCreator.CreateCounter(
 					_metricNameBuilder.BuildFullMetricName($"{metricNameBase}_Total"),
 					$"{metricDescriptionBase} - total value",
-					counterConfiguration),
-				_metricFactory.CreateCounter(
+					totalLabelNames),
+				_metricCreator.CreateCounter(
 					_metricNameBuilder.BuildFullMetricName(metricNameBase),
 					metricDescriptionBase,
-					new CounterConfiguration { LabelNames = stepLabelNames })
-				);
+					stepLabelNames));
 
 			_dynamicStepsPrometheusCounters[counterSetKey] = counterSet;
 		}
@@ -114,11 +107,14 @@ internal class DynamicStepsPrometheusAdapter
 
 	private class StepPrometheusCounterSet
 	{
-		public Counter CountCounter { get; }
-		public Counter TotalCounter { get; }
-		public Counter StepCounter { get; }
+		public ILabeledMetric CountCounter { get; }
+		public ILabeledMetric TotalCounter { get; }
+		public ILabeledMetric StepCounter { get; }
 
-		public StepPrometheusCounterSet(Counter countCounter, Counter totalCounter, Counter stepCounter)
+		public StepPrometheusCounterSet(
+			ILabeledMetric countCounter,
+			ILabeledMetric totalCounter,
+			ILabeledMetric stepCounter)
 		{
 			CountCounter = countCounter;
 			TotalCounter = totalCounter;

--- a/src/Prometheus/DynamicStepsPrometheusAdapter.cs
+++ b/src/Prometheus/DynamicStepsPrometheusAdapter.cs
@@ -107,14 +107,14 @@ internal class DynamicStepsPrometheusAdapter
 
 	private class StepPrometheusCounterSet
 	{
-		public ILabeledMetric CountCounter { get; }
-		public ILabeledMetric TotalCounter { get; }
-		public ILabeledMetric StepCounter { get; }
+		public ICounterAdapter CountCounter { get; }
+		public ICounterAdapter TotalCounter { get; }
+		public ICounterAdapter StepCounter { get; }
 
 		public StepPrometheusCounterSet(
-			ILabeledMetric countCounter,
-			ILabeledMetric totalCounter,
-			ILabeledMetric stepCounter)
+			ICounterAdapter countCounter,
+			ICounterAdapter totalCounter,
+			ICounterAdapter stepCounter)
 		{
 			CountCounter = countCounter;
 			TotalCounter = totalCounter;

--- a/src/Prometheus/PrometheusDiagnosticContextFactory.cs
+++ b/src/Prometheus/PrometheusDiagnosticContextFactory.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Mindbox.DiagnosticContext.MetricsTypes;
 using Prometheus;
 
@@ -19,9 +20,11 @@ namespace Mindbox.DiagnosticContext.Prometheus;
 
 public class PrometheusDiagnosticContextFactory : IDiagnosticContextFactory
 {
+	public static readonly TimeSpan DefaultMetricLifetime = TimeSpan.FromMinutes(5);
+
 	private readonly DefaultMetricTypesConfiguration _defaultMetricTypesConfiguration;
 	private readonly IDiagnosticContextLogger _diagnosticContextLogger;
-	private readonly IMetricFactory _metricFactory;
+	private readonly DiagnosticMetricCreator _metricCreator;
 	private readonly PrometheusMetricNameBuilder _metricNameBuilder;
 
 	public PrometheusDiagnosticContextFactory(
@@ -33,7 +36,24 @@ public class PrometheusDiagnosticContextFactory : IDiagnosticContextFactory
 	{
 		_defaultMetricTypesConfiguration = defaultMetricTypesConfiguration;
 		_diagnosticContextLogger = diagnosticContextLogger;
-		_metricFactory = metricFactory ?? Metrics.WithCustomRegistry(Metrics.DefaultRegistry);
+		_metricCreator = new DiagnosticMetricCreator(
+			metricFactory ?? Metrics.WithCustomRegistry(Metrics.DefaultRegistry));
+		_metricNameBuilder = new PrometheusMetricNameBuilder(prefix: metricPrefix, postfix: metricPostfix);
+	}
+
+	public PrometheusDiagnosticContextFactory(
+		DefaultMetricTypesConfiguration defaultMetricTypesConfiguration,
+		IDiagnosticContextLogger diagnosticContextLogger,
+		TimeSpan metricLifetime,
+		IMetricFactory? metricFactory = null,
+		string? metricPostfix = null,
+		string? metricPrefix = null)
+	{
+		_defaultMetricTypesConfiguration = defaultMetricTypesConfiguration;
+		_diagnosticContextLogger = diagnosticContextLogger;
+		var baseFactory = metricFactory ?? Metrics.WithCustomRegistry(Metrics.DefaultRegistry);
+		_metricCreator = new DiagnosticMetricCreator(
+			baseFactory.WithManagedLifetime(metricLifetime));
 		_metricNameBuilder = new PrometheusMetricNameBuilder(prefix: metricPrefix, postfix: metricPostfix);
 	}
 
@@ -42,7 +62,7 @@ public class PrometheusDiagnosticContextFactory : IDiagnosticContextFactory
 		bool isFeatureBoundaryCodePoint = false,
 		MetricsType[]? metricsTypesOverride = null)
 	{
-		var collection = new PrometheusDiagnosticContextMetricsCollection(_metricFactory, _metricNameBuilder);
+		var collection = new PrometheusDiagnosticContextMetricsCollection(_metricCreator, _metricNameBuilder);
 
 		return DiagnosticContextFactory.BuildCustom(
 			() =>

--- a/src/Prometheus/PrometheusDiagnosticContextMetricsCollection.cs
+++ b/src/Prometheus/PrometheusDiagnosticContextMetricsCollection.cs
@@ -15,7 +15,6 @@
 using System;
 using System.Collections.Generic;
 using Mindbox.DiagnosticContext.MetricItem;
-using Prometheus;
 
 namespace Mindbox.DiagnosticContext.Prometheus;
 
@@ -33,13 +32,13 @@ internal class PrometheusDiagnosticContextMetricsCollection : IDiagnosticContext
 	private readonly object _syncRoot = new();
 
 	public PrometheusDiagnosticContextMetricsCollection(
-		IMetricFactory metricFactory,
+		DiagnosticMetricCreator metricCreator,
 		PrometheusMetricNameBuilder metricNameBuilder)
 	{
-		_dynamicStepsAdapter = new DynamicStepsPrometheusAdapter(metricFactory, metricNameBuilder);
-		_countersAdapter = new CountersPrometheusAdapter(metricFactory, metricNameBuilder);
-		_reportedValuesAdapter = new ReportedValuesPrometheusAdapter(metricFactory, metricNameBuilder);
-		_internalMetricsAdapter = new DiagnosticContextInternalMetricsAdapter(metricFactory, metricNameBuilder);
+		_dynamicStepsAdapter = new DynamicStepsPrometheusAdapter(metricCreator, metricNameBuilder);
+		_countersAdapter = new CountersPrometheusAdapter(metricCreator, metricNameBuilder);
+		_reportedValuesAdapter = new ReportedValuesPrometheusAdapter(metricCreator, metricNameBuilder);
+		_internalMetricsAdapter = new DiagnosticContextInternalMetricsAdapter(metricCreator, metricNameBuilder);
 	}
 
 	public void CollectItemData(DiagnosticContextMetricsItem metricsItem)

--- a/src/Prometheus/ReportedValuesPrometheusAdapter.cs
+++ b/src/Prometheus/ReportedValuesPrometheusAdapter.cs
@@ -26,9 +26,9 @@ internal class ReportedValuesPrometheusAdapter
 
 	private struct ReportedValuesCounters
 	{
-		public ILabeledMetric Count { get; set; }
+		public ICounterAdapter Count { get; set; }
 
-		public ILabeledMetric Total { get; set; }
+		public ICounterAdapter Total { get; set; }
 	}
 
 	private readonly Dictionary<string, ReportedValuesCounters> _counters =

--- a/src/Prometheus/ReportedValuesPrometheusAdapter.cs
+++ b/src/Prometheus/ReportedValuesPrometheusAdapter.cs
@@ -1,11 +1,11 @@
 // Copyright 2021 Mindbox Ltd
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,29 +15,28 @@
 using System.Collections.Generic;
 using System.Linq;
 using Mindbox.DiagnosticContext.MetricItem;
-using Prometheus;
 
 namespace Mindbox.DiagnosticContext.Prometheus;
 
 internal class ReportedValuesPrometheusAdapter
 {
-	private readonly IMetricFactory _metricFactory;
+	private readonly DiagnosticMetricCreator _metricCreator;
 
 	private readonly PrometheusMetricNameBuilder _metricNameBuilder;
 
 	private struct ReportedValuesCounters
 	{
-		public Counter Count { get; set; }
+		public ILabeledMetric Count { get; set; }
 
-		public Counter Total { get; set; }
+		public ILabeledMetric Total { get; set; }
 	}
 
 	private readonly Dictionary<string, ReportedValuesCounters> _counters =
 		new();
 
-	public ReportedValuesPrometheusAdapter(IMetricFactory metricFactory, PrometheusMetricNameBuilder metricNameBuilder)
+	public ReportedValuesPrometheusAdapter(DiagnosticMetricCreator metricCreator, PrometheusMetricNameBuilder metricNameBuilder)
 	{
-		_metricFactory = metricFactory;
+		_metricCreator = metricCreator;
 		_metricNameBuilder = metricNameBuilder;
 	}
 
@@ -60,15 +59,8 @@ internal class ReportedValuesPrometheusAdapter
 
 					var labelValuesArray = labelValues.ToArray();
 
-					prometheusCounter
-						.Total
-						.WithLabels(labelValuesArray)
-						.Inc(diagnosticContextCounter.Value.Total);
-
-					prometheusCounter
-						.Count
-						.WithLabels(labelValuesArray)
-						.Inc(diagnosticContextCounter.Value.Count);
+					prometheusCounter.Total.Inc(labelValuesArray, diagnosticContextCounter.Value.Total);
+					prometheusCounter.Count.Inc(labelValuesArray, diagnosticContextCounter.Value.Count);
 				}
 			}
 		}
@@ -89,18 +81,18 @@ internal class ReportedValuesPrometheusAdapter
 
 		var labelNames = new List<string> { "name" };
 		labelNames.AddRange(tags.Keys);
-		var counterConfiguration = new CounterConfiguration { LabelNames = labelNames.ToArray() };
+		var labelNamesArray = labelNames.ToArray();
 
 		_counters[counterName] = new ReportedValuesCounters
 		{
-			Total = _metricFactory.CreateCounter(
+			Total = _metricCreator.CreateCounter(
 				totalMetricName,
 				totalMetricDescription,
-				counterConfiguration),
-			Count = _metricFactory.CreateCounter(
+				labelNamesArray),
+			Count = _metricCreator.CreateCounter(
 				reportedValuesMetricName,
 				reportedValuesMetricDescription,
-				counterConfiguration)
+				labelNamesArray)
 		};
 
 		return _counters[counterName];

--- a/src/Prometheus/ServiceCollectionExtensions.cs
+++ b/src/Prometheus/ServiceCollectionExtensions.cs
@@ -1,17 +1,18 @@
 // Copyright 2021 Mindbox Ltd
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Mindbox.DiagnosticContext;
 using Mindbox.DiagnosticContext.MetricsTypes;
 using Mindbox.DiagnosticContext.Prometheus;
@@ -22,12 +23,8 @@ public static class PrometheusDiagnosticContextExtensions
 {
 	/// <summary>
 	/// Adds all the necessary dependencies to collect metrics in Prometheus.
+	/// Metric series live indefinitely (no automatic eviction).
 	/// </summary>
-	/// <param name="serviceCollection">The <see cref="IServiceCollection"/> to add the service to.</param>
-	/// <param name="prefix">String constant which will be added at the beginning of each metric name.
-	/// It is strongly recommended to use a unique prefix that includes the name of the application -
-	/// this can guarantee that there is no intersection of metrics.</param>
-	/// <returns></returns>
 	public static IServiceCollection AddPrometheusDiagnosticContext(
 		this IServiceCollection serviceCollection,
 		string? prefix = null)
@@ -36,5 +33,25 @@ public static class PrometheusDiagnosticContextExtensions
 				new PrometheusDiagnosticContextFactory(
 					serviceProvider.GetRequiredService<DefaultMetricTypesConfiguration>(),
 					serviceProvider.GetRequiredService<IDiagnosticContextLogger>(),
+					metricPrefix: prefix));
+
+	/// <summary>
+	/// Adds all the necessary dependencies to collect metrics in Prometheus
+	/// with automatic eviction of inactive time series.
+	/// </summary>
+	/// <param name="serviceCollection">The <see cref="IServiceCollection"/> to add the service to.</param>
+	/// <param name="metricLifetime">Time after which an unused metric series is automatically removed.
+	/// Defaults to <see cref="PrometheusDiagnosticContextFactory.DefaultMetricLifetime"/> (5 minutes).</param>
+	/// <param name="prefix">Prefix added to each metric name.</param>
+	public static IServiceCollection AddPrometheusDiagnosticContextWithManagedLifetime(
+		this IServiceCollection serviceCollection,
+		TimeSpan? metricLifetime = null,
+		string? prefix = null)
+		=> serviceCollection.AddSingleton<IDiagnosticContextFactory, PrometheusDiagnosticContextFactory>(
+			serviceProvider =>
+				new PrometheusDiagnosticContextFactory(
+					serviceProvider.GetRequiredService<DefaultMetricTypesConfiguration>(),
+					serviceProvider.GetRequiredService<IDiagnosticContextLogger>(),
+					metricLifetime ?? PrometheusDiagnosticContextFactory.DefaultMetricLifetime,
 					metricPrefix: prefix));
 }


### PR DESCRIPTION
#### Summary

  Добавлена поддержка автоматического выселения неактивных серий метрик через prometheus-net managed lifetime API (WithManagedLifetime + WithExtendLifetimeOnUse).

  **Проблема**: DiagnosticContext создаёт серии через .WithLabels() без механизма удаления — при высокой кардинальности тегов серии копятся в памяти до OOM-рестарта контейнера.

  **Решение**: Новый конструктор PrometheusDiagnosticContextFactory(config, logger, metricLifetime, ...) создаёт фабрику, где серии автоматически удаляются после metricLifetime неактивности (дефолт 5 минут). Старый
  конструктор без TimeSpan работает как раньше — полная обратная совместимость.

 #### Что изменено

  - DiagnosticMetricCreator (новый) — абстрагирует создание метрик для обоих путей (plain IMetricFactory и managed IManagedLifetimeMetricFactory)
  - PrometheusDiagnosticContextFactory — два конструктора: plain (обратная совместимость) и managed (с TTL)
  - Все 4 адаптера — используют DiagnosticMetricCreator вместо прямого IMetricFactory
  - ServiceCollectionExtensions — добавлен AddPrometheusDiagnosticContextWithManagedLifetime()
  - Тесты — все 18 тестов параметризованы через наследование (plain + managed), + тест на выселение

 #### Как подключить

  // Вместо:
  services.AddPrometheusDiagnosticContext(prefix: "myapp");

  // Использовать:
  services.AddPrometheusDiagnosticContextWithManagedLifetime(prefix: "myapp");
  // или с кастомным TTL:
  services.AddPrometheusDiagnosticContextWithManagedLifetime(
      metricLifetime: TimeSpan.FromMinutes(10), prefix: "myapp");

#### Связанная задача:
https://tracker.yandex.ru/DBMISSIONS-978