### PR TITLE
Mark plain DiagnosticContext factory as Obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,21 @@ Add a reference to `Mindbox.DiagnosticContext.Prometheus` package. Then, add thi
 
 ```csharp
 services
-  .AddPrometheusDiagnosticContext("orders");
+  .AddPrometheusDiagnosticContextWithManagedLifetime(prefix: "orders");
 ```
+
+This registers a factory that automatically evicts inactive metric series after 5 minutes (default). You can customize the lifetime:
+
+```csharp
+services
+  .AddPrometheusDiagnosticContextWithManagedLifetime(
+      metricLifetime: TimeSpan.FromMinutes(10),
+      prefix: "orders");
+```
+
 It is strongly recommended to use a unique prefix that includes the name of the application - this can guarantee that there is no intersection of metrics.
+
+> **Note:** The previous `AddPrometheusDiagnosticContext` method (without managed lifetime) is now marked as `[Obsolete]`. It creates metric series that live indefinitely, which can lead to OOM in high-cardinality scenarios.
 
 If your application doesn't yet expose prometheus metrics, add the following code to your `Startup` class or use the [prometheus-net documentation](https://github.com/prometheus-net/prometheus-net) to instrument your code: 
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ services
 
 It is strongly recommended to use a unique prefix that includes the name of the application - this can guarantee that there is no intersection of metrics.
 
-> **Note:** The previous `AddPrometheusDiagnosticContext` method (without managed lifetime) is now marked as `[Obsolete]`. It creates metric series that live indefinitely, which can lead to OOM in high-cardinality scenarios.
+> **Note:** The previous `AddPrometheusDiagnosticContext` method (without managed lifetime) is now marked as `[Obsolete]`. It creates metric series that live indefinitely.
 
 If your application doesn't yet expose prometheus metrics, add the following code to your `Startup` class or use the [prometheus-net documentation](https://github.com/prometheus-net/prometheus-net) to instrument your code: 
 

--- a/src/AspNetCoreTestProject/Controllers/TestController.cs
+++ b/src/AspNetCoreTestProject/Controllers/TestController.cs
@@ -1,11 +1,11 @@
 // Copyright 2021 Mindbox Ltd
-//
+// 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
+// 
 //     http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.Threading;
 using Microsoft.AspNetCore.Mvc;
 using Mindbox.DiagnosticContext.AspNetCore;
 
@@ -29,13 +28,9 @@ public class TestController : Controller
 
 		using (diagnosticContext.Measure("outer"))
 		{
-			Thread.Sleep(TimeSpan.FromMilliseconds(new Random().Next(1, 100)));
 			diagnosticContext.ReportValue("reported", DateTime.Now.Minute);
 			using (diagnosticContext.Measure("inner"))
-			{
-				Thread.Sleep(TimeSpan.FromMilliseconds(new Random().Next(1, 100)));
 				return Ok();
-			}
 		}
 	}
 }

--- a/src/AspNetCoreTestProject/Controllers/TestController.cs
+++ b/src/AspNetCoreTestProject/Controllers/TestController.cs
@@ -1,11 +1,11 @@
 // Copyright 2021 Mindbox Ltd
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System;
+using System.Threading;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Mindbox.DiagnosticContext.AspNetCore;
 
@@ -28,9 +30,13 @@ public class TestController : Controller
 
 		using (diagnosticContext.Measure("outer"))
 		{
+			Thread.Sleep(TimeSpan.FromMilliseconds(new Random().Next(1, 100)));
 			diagnosticContext.ReportValue("reported", DateTime.Now.Minute);
 			using (diagnosticContext.Measure("inner"))
+			{
+				Thread.Sleep(TimeSpan.FromMilliseconds(new Random().Next(1, 100)));
 				return Ok();
+			}
 		}
 	}
 }

--- a/src/AspNetCoreTestProject/Controllers/TestController.cs
+++ b/src/AspNetCoreTestProject/Controllers/TestController.cs
@@ -14,7 +14,6 @@
 
 using System;
 using System.Threading;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Mindbox.DiagnosticContext.AspNetCore;
 

--- a/src/AspNetCoreTestProject/NullDiagnosticContextLogger.cs
+++ b/src/AspNetCoreTestProject/NullDiagnosticContextLogger.cs
@@ -1,0 +1,31 @@
+// Copyright 2021 Mindbox Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Mindbox.DiagnosticContext;
+
+namespace AspNetCoreTestProject;
+
+public class NullDiagnosticContextLogger : IDiagnosticContextLogger
+{
+	public void Log(
+		string message,
+		Exception? exception,
+		LogLevel? logLevel = null,
+		IDictionary<string, object>? additionalProperties = null)
+	{
+	}
+}

--- a/src/AspNetCoreTestProject/Startup.cs
+++ b/src/AspNetCoreTestProject/Startup.cs
@@ -39,7 +39,7 @@ public class Startup
 
 		services
 			.AddSingleton<DefaultMetricTypesConfiguration>()
-			.AddSingleton<IDiagnosticContextLogger>(new NullLogger())
+			.AddSingleton<IDiagnosticContextLogger, NullDiagnosticContextLogger>()
 			.AddPrometheusDiagnosticContextWithManagedLifetime(prefix: "AspNetCoreTestProject", metricLifetime: TimeSpan.FromSeconds(30));
 	}
 
@@ -64,7 +64,7 @@ public class Startup
 	}
 }
 
-public class NullLogger : IDiagnosticContextLogger
+public class NullDiagnosticContextLogger : IDiagnosticContextLogger
 {
 	public void Log(
 		string message,

--- a/src/AspNetCoreTestProject/Startup.cs
+++ b/src/AspNetCoreTestProject/Startup.cs
@@ -1,21 +1,26 @@
 // Copyright 2021 Mindbox Ltd
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Mindbox.DiagnosticContext;
+using Mindbox.DiagnosticContext.MetricsTypes;
 using Prometheus;
 
 namespace AspNetCoreTestProject;
@@ -33,7 +38,7 @@ public class Startup
 			.AddControllers();
 
 		services
-			.AddPrometheusDiagnosticContext(prefix: "AspNetCoreTestProject");
+			.AddPrometheusDiagnosticContextWithManagedLifetime(prefix: "AspNetCoreTestProject");
 	}
 
 	// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -54,5 +59,16 @@ public class Startup
 			{
 				endpoints.MapControllers();
 			});
+	}
+}
+
+public class NullLogger : IDiagnosticContextLogger
+{
+	public void Log(
+		string message,
+		Exception? exception,
+		LogLevel? logLevel = null,
+		IDictionary<string, object>? additionalProperties = null)
+	{
 	}
 }

--- a/src/AspNetCoreTestProject/Startup.cs
+++ b/src/AspNetCoreTestProject/Startup.cs
@@ -38,7 +38,9 @@ public class Startup
 			.AddControllers();
 
 		services
-			.AddPrometheusDiagnosticContextWithManagedLifetime(prefix: "AspNetCoreTestProject");
+			.AddSingleton<DefaultMetricTypesConfiguration>()
+			.AddSingleton<IDiagnosticContextLogger>(new NullLogger())
+			.AddPrometheusDiagnosticContextWithManagedLifetime(prefix: "AspNetCoreTestProject", metricLifetime: TimeSpan.FromSeconds(30));
 	}
 
 	// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/AspNetCoreTestProject/Startup.cs
+++ b/src/AspNetCoreTestProject/Startup.cs
@@ -13,12 +13,10 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Mindbox.DiagnosticContext;
 using Mindbox.DiagnosticContext.MetricsTypes;
 using Prometheus;
@@ -61,16 +59,5 @@ public class Startup
 			{
 				endpoints.MapControllers();
 			});
-	}
-}
-
-public class NullDiagnosticContextLogger : IDiagnosticContextLogger
-{
-	public void Log(
-		string message,
-		Exception? exception,
-		LogLevel? logLevel = null,
-		IDictionary<string, object>? additionalProperties = null)
-	{
 	}
 }

--- a/src/Benchmarks/Benchmark.cs
+++ b/src/Benchmarks/Benchmark.cs
@@ -21,10 +21,12 @@ namespace Mindbox.DiagnosticContext.Benchmarks;
 [MemoryDiagnoser]
 public class DiagnosticContextBenchmarks
 {
+#pragma warning disable CS0618
 	private readonly IDiagnosticContextFactory _diagnosticContextFactory = new PrometheusDiagnosticContextFactory(
 		new DefaultMetricTypesConfiguration(),
 		new NullDiagnosticContextLogger()
 	);
+#pragma warning restore CS0618
 
 	[Benchmark]
 	public void WithoutSteps()

--- a/src/Benchmarks/Benchmark.cs
+++ b/src/Benchmarks/Benchmark.cs
@@ -21,12 +21,11 @@ namespace Mindbox.DiagnosticContext.Benchmarks;
 [MemoryDiagnoser]
 public class DiagnosticContextBenchmarks
 {
-#pragma warning disable CS0618
 	private readonly IDiagnosticContextFactory _diagnosticContextFactory = new PrometheusDiagnosticContextFactory(
 		new DefaultMetricTypesConfiguration(),
-		new NullDiagnosticContextLogger()
+		new NullDiagnosticContextLogger(),
+		PrometheusDiagnosticContextFactory.DefaultMetricLifetime
 	);
-#pragma warning restore CS0618
 
 	[Benchmark]
 	public void WithoutSteps()

--- a/src/Prometheus.Tests/DiagnosticContextTests.cs
+++ b/src/Prometheus.Tests/DiagnosticContextTests.cs
@@ -472,11 +472,13 @@ public abstract class DiagnosticContextTestsBase
 [TestClass]
 public class PlainDiagnosticContextTests : DiagnosticContextTestsBase
 {
+#pragma warning disable CS0618
 	protected override PrometheusDiagnosticContextFactory CreateFactory(
 		DefaultMetricTypesConfiguration config,
 		IDiagnosticContextLogger logger,
 		IMetricFactory metricFactory)
 		=> new(config, logger, metricFactory);
+#pragma warning restore CS0618
 }
 
 [TestClass]

--- a/src/Prometheus/PrometheusDiagnosticContextFactory.cs
+++ b/src/Prometheus/PrometheusDiagnosticContextFactory.cs
@@ -27,6 +27,7 @@ public class PrometheusDiagnosticContextFactory : IDiagnosticContextFactory
 	private readonly DiagnosticMetricCreator _metricCreator;
 	private readonly PrometheusMetricNameBuilder _metricNameBuilder;
 
+	[Obsolete("Use the constructor with metricLifetime parameter to enable automatic eviction of inactive series.")]
 	public PrometheusDiagnosticContextFactory(
 		DefaultMetricTypesConfiguration defaultMetricTypesConfiguration,
 		IDiagnosticContextLogger diagnosticContextLogger,

--- a/src/Prometheus/ServiceCollectionExtensions.cs
+++ b/src/Prometheus/ServiceCollectionExtensions.cs
@@ -25,15 +25,18 @@ public static class PrometheusDiagnosticContextExtensions
 	/// Adds all the necessary dependencies to collect metrics in Prometheus.
 	/// Metric series live indefinitely (no automatic eviction).
 	/// </summary>
+	[Obsolete("Use AddPrometheusDiagnosticContextWithManagedLifetime to enable automatic eviction of inactive series.")]
 	public static IServiceCollection AddPrometheusDiagnosticContext(
 		this IServiceCollection serviceCollection,
 		string? prefix = null)
+#pragma warning disable CS0618
 		=> serviceCollection.AddSingleton<IDiagnosticContextFactory, PrometheusDiagnosticContextFactory>(
 			serviceProvider =>
 				new PrometheusDiagnosticContextFactory(
 					serviceProvider.GetRequiredService<DefaultMetricTypesConfiguration>(),
 					serviceProvider.GetRequiredService<IDiagnosticContextLogger>(),
 					metricPrefix: prefix));
+#pragma warning restore CS0618
 
 	/// <summary>
 	/// Adds all the necessary dependencies to collect metrics in Prometheus


### PR DESCRIPTION
 ## Summary

  - Помечены `[Obsolete]` старый конструктор `PrometheusDiagnosticContextFactory` (без `metricLifetime`) и extension `AddPrometheusDiagnosticContext`
  - Тестовый проект (`AspNetCoreTestProject`) и бенчмарки мигрированы на `AddPrometheusDiagnosticContextWithManagedLifetime`
  - `#pragma warning disable CS0618` в тестах для подавления warning'а
  - Пофикшен тестовый проект

  ## Связанная задача

  https://tracker.yandex.ru/DBMISSIONS-978